### PR TITLE
fix: remove redundant CI triggers and add tests to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
     branches: [master]
+    tags-ignore:
+      - "v*"
   pull_request:
     branches: [master]
 
@@ -24,9 +26,3 @@ jobs:
 
       - name: Build
         run: CGO_ENABLED=1 go build -ldflags="-s -w" -o scrawl .
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: scrawl-linux-amd64
-          path: scrawl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install cross-compilation dependencies
         run: sudo apt-get update && sudo apt-get install -y gcc gcc-aarch64-linux-gnu
 
+      - name: Test
+        run: go test -v -count=1 ./...
+
       - name: Build linux/amd64
         run: CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o scrawl-linux-amd64 .
 


### PR DESCRIPTION
## Summary

- **build.yml**: Add `tags-ignore: v*` so it doesn't run alongside the release workflow on tag pushes
- **build.yml**: Remove artifact upload (releases handle binary distribution)
- **release.yml**: Add test step before building release binaries to prevent broken releases

## Why

When a `v*` tag was pushed, both `build.yml` and `release.yml` triggered — duplicating checkout, Go setup, gcc install, and the amd64 build. The build artifact upload was also redundant since releases attach binaries directly.