### PR TITLE
add word count, download as txt, expiring entries

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -18,6 +18,7 @@ type Entry struct {
 	Title     string
 	Body      string
 	CreatedAt time.Time
+	ExpiresAt *time.Time
 }
 
 var tmpl *template.Template
@@ -99,6 +100,21 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 
 const maxBodySize = 128 * 1024 // 128KB
 
+var ttlOptions = map[string]time.Duration{
+	"1h":  time.Hour,
+	"1d":  24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+	"30d": 30 * 24 * time.Hour,
+}
+
+func parseTTL(val string) *time.Time {
+	if d, ok := ttlOptions[val]; ok {
+		t := time.Now().Add(d)
+		return &t
+	}
+	return nil
+}
+
 func handleCreate(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 
@@ -115,15 +131,22 @@ func handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := generateID()
+	expiresAt := parseTTL(r.FormValue("ttl"))
 
-	_, err := db.Exec("INSERT INTO entries (id, title, body) VALUES (?, ?, ?)", id, title, body)
+	var expiresStr *string
+	if expiresAt != nil {
+		s := expiresAt.Format(time.RFC3339)
+		expiresStr = &s
+	}
+
+	_, err := db.Exec("INSERT INTO entries (id, title, body, expires_at) VALUES (?, ?, ?, ?)", id, title, body, expiresStr)
 	if err != nil {
 		log.Println("error creating entry:", err)
 		http.Error(w, "Internal Server Error", 500)
 		return
 	}
 
-	entry := Entry{ID: id, Title: title, Body: body, CreatedAt: time.Now()}
+	entry := Entry{ID: id, Title: title, Body: body, CreatedAt: time.Now(), ExpiresAt: expiresAt}
 	entries, _ := listEntries(0)
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -208,7 +231,14 @@ func handleEdit(w http.ResponseWriter, r *http.Request) {
 		title = title[:maxTitleLen]
 	}
 
-	result, err := db.Exec("UPDATE entries SET title = ?, body = ? WHERE id = ?", title, body, id)
+	expiresAt := parseTTL(r.FormValue("ttl"))
+	var expiresStr *string
+	if expiresAt != nil {
+		s := expiresAt.Format(time.RFC3339)
+		expiresStr = &s
+	}
+
+	result, err := db.Exec("UPDATE entries SET title = ?, body = ?, expires_at = ? WHERE id = ?", title, body, expiresStr, id)
 	if err != nil {
 		log.Println("error updating entry:", err)
 		http.Error(w, "Internal Server Error", 500)
@@ -282,13 +312,31 @@ func handleDelete(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
+func handleDownload(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !validID.MatchString(id) {
+		http.NotFound(w, r)
+		return
+	}
+
+	entry, err := getEntry(id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+entry.Title+".txt\"")
+	w.Write([]byte(entry.Body))
+}
+
 // listEntries returns entries without body for sidebar display.
 func listEntries(page int) ([]Entry, error) {
 	limit := 20
 	offset := page * limit
 
 	rows, err := db.Query(
-		"SELECT id, title, created_at FROM entries ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?",
+		"SELECT id, title, created_at FROM entries WHERE expires_at IS NULL OR expires_at > datetime('now') ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?",
 		limit, offset,
 	)
 	if err != nil {
@@ -313,11 +361,29 @@ func listEntries(page int) ([]Entry, error) {
 func getEntry(id string) (*Entry, error) {
 	var entry Entry
 	var createdAt string
-	err := db.QueryRow("SELECT id, title, body, created_at FROM entries WHERE id = ?", id).
-		Scan(&entry.ID, &entry.Title, &entry.Body, &createdAt)
+	var expiresAt *string
+	err := db.QueryRow(
+		"SELECT id, title, body, created_at, expires_at FROM entries WHERE id = ? AND (expires_at IS NULL OR expires_at > datetime('now'))", id,
+	).Scan(&entry.ID, &entry.Title, &entry.Body, &createdAt, &expiresAt)
 	if err != nil {
 		return nil, err
 	}
 	entry.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	if expiresAt != nil {
+		t, _ := time.Parse(time.RFC3339, *expiresAt)
+		entry.ExpiresAt = &t
+	}
 	return &entry, nil
+}
+
+// cleanupExpired removes entries past their expiration.
+func cleanupExpired() {
+	result, err := db.Exec("DELETE FROM entries WHERE expires_at IS NOT NULL AND expires_at <= datetime('now')")
+	if err != nil {
+		log.Println("cleanup error:", err)
+		return
+	}
+	if n, _ := result.RowsAffected(); n > 0 {
+		log.Printf("cleaned up %d expired entries", n)
+	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -45,6 +45,7 @@ func newMux() *http.ServeMux {
 	mux.HandleFunc("PUT /api/entries/{id}", handleEdit)
 	mux.HandleFunc("GET /api/entries/{id}/edit", handleEditForm)
 	mux.HandleFunc("DELETE /api/entries/{id}", handleDelete)
+	mux.HandleFunc("GET /e/{id}/download", handleDownload)
 	mux.Handle("GET /static/", http.FileServerFS(staticFS))
 	return mux
 }
@@ -801,6 +802,204 @@ func TestInputSanitization(t *testing.T) {
 	body := readBody(t, resp)
 	assertContains(t, body, "Padded Title", "title should be trimmed")
 	assertNotContains(t, body, "\x00", "null bytes should be stripped")
+}
+
+func TestDownloadEntry(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createTestEntry(t, srv.URL, "Download Test", "downloadable content here")
+
+	resp, err := http.Get(srv.URL + "/e/" + id + "/download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", ct)
+	}
+
+	cd := resp.Header.Get("Content-Disposition")
+	if !strings.Contains(cd, "attachment") {
+		t.Fatalf("expected attachment disposition, got %q", cd)
+	}
+
+	body := readBody(t, resp)
+	if body != "downloadable content here" {
+		t.Fatalf("expected raw body content, got %q", body)
+	}
+}
+
+func TestDownloadEntry_NotFound(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/e/deadbeef/download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateEntryWithTTL(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	form := url.Values{"title": {"Expiring"}, "body": {"will expire"}, "ttl": {"1h"}}
+	resp, err := client.PostForm(srv.URL+"/api/entries", form)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 303 {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
+	}
+
+	id := strings.TrimPrefix(resp.Header.Get("Location"), "/e/")
+
+	entry, err := getEntry(id)
+	if err != nil {
+		t.Fatal("failed to get entry:", err)
+	}
+
+	if entry.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to be set")
+	}
+}
+
+func TestCreateEntryWithoutTTL(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	form := url.Values{"title": {"Permanent"}, "body": {"no expiry"}}
+	resp, err := client.PostForm(srv.URL+"/api/entries", form)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	id := strings.TrimPrefix(resp.Header.Get("Location"), "/e/")
+
+	entry, err := getEntry(id)
+	if err != nil {
+		t.Fatal("failed to get entry:", err)
+	}
+
+	if entry.ExpiresAt != nil {
+		t.Fatal("expected ExpiresAt to be nil for no-TTL entry")
+	}
+}
+
+func TestExpiredEntryNotVisible(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := generateID()
+	db.Exec("INSERT INTO entries (id, title, body, expires_at) VALUES (?, ?, ?, datetime('now', '-1 hour'))",
+		id, "Expired", "gone")
+
+	resp, err := http.Get(srv.URL + "/e/" + id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Fatalf("expected 404 for expired entry, got %d", resp.StatusCode)
+	}
+}
+
+func TestExpiredEntryNotInSidebar(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	db.Exec("INSERT INTO entries (id, title, body, expires_at) VALUES (?, ?, ?, datetime('now', '-1 hour'))",
+		"abcd1234", "Expired Sidebar", "gone")
+	createTestEntry(t, srv.URL, "Visible Entry", "still here")
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Visible Entry", "non-expired entry should appear")
+	assertNotContains(t, body, "Expired Sidebar", "expired entry should not appear in sidebar")
+}
+
+func TestViewEntryShowsDownloadButton(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createTestEntry(t, srv.URL, "Download Button", "content")
+
+	resp, err := http.Get(srv.URL + "/e/" + id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Download", "download button")
+}
+
+func TestEditorShowsTTLSelect(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	assertContains(t, body, "ttl-select", "TTL select element")
+	assertContains(t, body, "No expiry", "default no-expiry option")
 }
 
 // --- helpers ---

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -45,6 +46,8 @@ func main() {
 		log.Fatal("failed to initialize database:", err)
 	}
 
+	startCleanup()
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /", handleIndex)
@@ -54,6 +57,7 @@ func main() {
 	mux.HandleFunc("PUT /api/entries/{id}", handleEdit)
 	mux.HandleFunc("GET /api/entries/{id}/edit", handleEditForm)
 	mux.HandleFunc("DELETE /api/entries/{id}", handleDelete)
+	mux.HandleFunc("GET /e/{id}/download", handleDownload)
 	mux.Handle("GET /static/", cacheStatic(http.FileServerFS(staticFS)))
 
 	handler := securityHeaders(gzipHandler(mux))
@@ -70,11 +74,26 @@ func initDB() error {
 			id         TEXT PRIMARY KEY,
 			title      TEXT NOT NULL,
 			body       TEXT NOT NULL,
-			created_at DATETIME DEFAULT (datetime('now'))
+			created_at DATETIME DEFAULT (datetime('now')),
+			expires_at DATETIME
 		);
 		CREATE INDEX IF NOT EXISTS idx_entries_created ON entries(created_at DESC);
 	`)
-	return err
+	if err != nil {
+		return err
+	}
+	// migrate: add expires_at if upgrading from older schema
+	db.Exec("ALTER TABLE entries ADD COLUMN expires_at DATETIME")
+	return nil
+}
+
+func startCleanup() {
+	go func() {
+		for {
+			time.Sleep(10 * time.Minute)
+			cleanupExpired()
+		}
+	}()
 }
 
 func securityHeaders(next http.Handler) http.Handler {

--- a/static/style.css
+++ b/static/style.css
@@ -239,11 +239,43 @@ html, body {
     border-color: var(--accent);
 }
 
+.editor-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 10px;
+    gap: 12px;
+}
+
+.char-count {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+}
+
 .form-actions {
     display: flex;
-    justify-content: flex-end;
-    margin-top: 12px;
+    align-items: center;
     gap: 8px;
+    flex-shrink: 0;
+}
+
+.ttl-select {
+    padding: 5px 10px;
+    font-size: 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text);
+    cursor: pointer;
+    font-family: var(--font-sans);
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.ttl-select:hover, .ttl-select:focus {
+    border-color: var(--accent);
 }
 
 /* Buttons */

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,9 +67,19 @@
         document.getElementById('content-area').innerHTML = `
             <form hx-post="/api/entries" hx-target="#content-area" hx-swap="innerHTML">
                 <input type="text" name="title" placeholder="Heading" class="input-title" required autofocus>
-                <textarea name="body" placeholder="Paste your text here..." class="input-body" required></textarea>
-                <div class="form-actions">
-                    <button type="submit" class="btn btn-primary">Save</button>
+                <textarea name="body" placeholder="Paste your text here..." class="input-body" required oninput="updateCount(this)"></textarea>
+                <div class="editor-footer">
+                    <span class="char-count">0 chars · 0 words</span>
+                    <div class="form-actions">
+                        <select name="ttl" class="ttl-select">
+                            <option value="">No expiry</option>
+                            <option value="1h">1 hour</option>
+                            <option value="1d">1 day</option>
+                            <option value="7d">7 days</option>
+                            <option value="30d">30 days</option>
+                        </select>
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
                 </div>
             </form>
         `;
@@ -114,6 +124,16 @@
         const path = window.location.pathname;
         if (path.startsWith('/e/')) setActive(path.split('/e/')[1]);
     });
+    function updateCount(el) {
+        const text = el.value;
+        const chars = text.length;
+        const words = text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+        const counter = el.closest('form').querySelector('.char-count');
+        if (counter) counter.textContent = chars + ' chars · ' + words + ' words';
+    }
+    function downloadEntry(id) {
+        window.location.href = '/e/' + id + '/download';
+    }
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape') closeModal();
         if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
@@ -133,9 +153,19 @@
 
 {{define "form-fields"}}
 <input type="text" name="title" placeholder="Heading" class="input-title" required autofocus>
-<textarea name="body" placeholder="Paste your text here..." class="input-body" required></textarea>
-<div class="form-actions">
-    <button type="submit" class="btn btn-primary">Save</button>
+<textarea name="body" placeholder="Paste your text here..." class="input-body" required oninput="updateCount(this)"></textarea>
+<div class="editor-footer">
+    <span class="char-count">0 chars · 0 words</span>
+    <div class="form-actions">
+        <select name="ttl" class="ttl-select">
+            <option value="">No expiry</option>
+            <option value="1h">1 hour</option>
+            <option value="1d">1 day</option>
+            <option value="7d">7 days</option>
+            <option value="30d">30 days</option>
+        </select>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </div>
 </div>
 {{end}}
 
@@ -172,11 +202,12 @@
     <div class="view-topbar">
         <button class="btn btn-small" id="copytxt-btn-{{.ID}}" onclick="copyText('{{.ID}}')">Copy Text</button>
         <button class="btn btn-small" id="copy-btn-{{.ID}}" onclick="copyLink('{{.ID}}')">Copy Link</button>
+        <button class="btn btn-small" onclick="downloadEntry('{{.ID}}')">Download</button>
         <button class="btn btn-small" hx-get="/api/entries/{{.ID}}/edit" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
         <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.ID}}')">Delete</button>
     </div>
     <h1 class="view-title">{{.Title}}</h1>
-    <time class="view-time">{{.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}</time>
+    <time class="view-time">{{.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}{{if .ExpiresAt}} · expires {{.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}</time>
     <pre class="view-body">{{.Body}}</pre>
 </article>
 <script>setActive('{{.ID}}');</script>
@@ -185,12 +216,28 @@
 {{define "edit-form"}}
 <form hx-put="/api/entries/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML">
     <input type="text" name="title" value="{{.Title}}" class="input-title" required autofocus>
-    <textarea name="body" class="input-body" required>{{.Body}}</textarea>
-    <div class="form-actions">
-        <button type="button" class="btn btn-small" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML">Cancel</button>
-        <button type="submit" class="btn btn-primary">Save Changes</button>
+    <textarea name="body" class="input-body" required oninput="updateCount(this)">{{.Body}}</textarea>
+    <div class="editor-footer">
+        <span class="char-count">0 chars · 0 words</span>
+        <div class="form-actions">
+            <select name="ttl" class="ttl-select">
+                <option value="">No expiry</option>
+                <option value="1h">1 hour</option>
+                <option value="1d">1 day</option>
+                <option value="7d">7 days</option>
+                <option value="30d">30 days</option>
+            </select>
+            <button type="button" class="btn btn-small" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML">Cancel</button>
+            <button type="submit" class="btn btn-primary">Save Changes</button>
+        </div>
     </div>
 </form>
+<script>
+(function() {
+    const ta = document.querySelector('.input-body');
+    if (ta) updateCount(ta);
+})();
+</script>
 {{end}}
 
 {{define "edited-response"}}
@@ -201,11 +248,12 @@
     <div class="view-topbar">
         <button class="btn btn-small" id="copytxt-btn-{{.Entry.ID}}" onclick="copyText('{{.Entry.ID}}')">Copy Text</button>
         <button class="btn btn-small" id="copy-btn-{{.Entry.ID}}" onclick="copyLink('{{.Entry.ID}}')">Copy Link</button>
+        <button class="btn btn-small" onclick="downloadEntry('{{.Entry.ID}}')">Download</button>
         <button class="btn btn-small" hx-get="/api/entries/{{.Entry.ID}}/edit" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
         <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.Entry.ID}}')">Delete</button>
     </div>
     <h1 class="view-title">{{.Entry.Title}}</h1>
-    <time class="view-time">{{.Entry.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}</time>
+    <time class="view-time">{{.Entry.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}{{if .Entry.ExpiresAt}} · expires {{.Entry.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}</time>
     <pre class="view-body">{{.Entry.Body}}</pre>
 </article>
 <script>
@@ -228,11 +276,12 @@ setTimeout(() => {
     <div class="view-topbar">
         <button class="btn btn-small" id="copytxt-btn-{{.ID}}" onclick="copyText('{{.ID}}')">Copy Text</button>
         <button class="btn btn-small" id="copy-btn-{{.ID}}" onclick="copyLink('{{.ID}}')">Copy Link</button>
+        <button class="btn btn-small" onclick="downloadEntry('{{.ID}}')">Download</button>
         <button class="btn btn-small" hx-get="/api/entries/{{.ID}}/edit" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
         <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.ID}}')">Delete</button>
     </div>
     <h1 class="view-title">{{.Entry.Title}}</h1>
-    <time class="view-time">just now</time>
+    <time class="view-time">just now{{if .Entry.ExpiresAt}} · expires {{.Entry.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}</time>
     <pre class="view-body">{{.Entry.Body}}</pre>
 </article>
 <script>
@@ -247,9 +296,19 @@ setActive('{{.ID}}');
 <div class="deleted-banner">Entry deleted.</div>
 <form hx-post="/api/entries" hx-target="#content-area" hx-swap="innerHTML">
     <input type="text" name="title" placeholder="Heading" class="input-title" required autofocus>
-    <textarea name="body" placeholder="Paste your text here..." class="input-body" required></textarea>
-    <div class="form-actions">
-        <button type="submit" class="btn btn-primary">Save</button>
+    <textarea name="body" placeholder="Paste your text here..." class="input-body" required oninput="updateCount(this)"></textarea>
+    <div class="editor-footer">
+        <span class="char-count">0 chars · 0 words</span>
+        <div class="form-actions">
+            <select name="ttl" class="ttl-select">
+                <option value="">No expiry</option>
+                <option value="1h">1 hour</option>
+                <option value="1d">1 day</option>
+                <option value="7d">7 days</option>
+                <option value="30d">30 days</option>
+            </select>
+            <button type="submit" class="btn btn-primary">Save</button>
+        </div>
     </div>
 </form>
 <script>


### PR DESCRIPTION
## Summary
- Live word/character count in editor footer
- Download as .txt button on view page (`GET /e/{id}/download`)
- Optional TTL on entries (1h, 1d, 7d, 30d — default: never)
- Background goroutine cleans up expired entries every 10 minutes
- Graceful schema migration for `expires_at` column
- 8 new integration tests (35 total)