### PR TITLE
update changelog for v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-03
+
+### Added
+
+- Live word/character count in editor footer
+- Download as `.txt` button on view page (`GET /e/{id}/download`)
+- Expiring entries with optional TTL (1 hour, 1 day, 7 days, 30 days — default: never)
+- Background cleanup goroutine for expired entries (runs every 10 minutes)
+- Graceful schema migration for `expires_at` column
+
 ## [1.1.0] - 2026-03-03
 
 ### Added
@@ -41,5 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot with auto-merge for Go modules and GitHub Actions
 - MIT license
 
+[1.2.0]: https://github.com/dasunNimantha/scrawl/releases/tag/v1.2.0
 [1.1.0]: https://github.com/dasunNimantha/scrawl/releases/tag/v1.1.0
 [1.0.0]: https://github.com/dasunNimantha/scrawl/releases/tag/v1.0.0


### PR DESCRIPTION
Add v1.2.0 changelog entry: word count, download as txt, expiring entries.