### PR TITLE
add password protection for entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module scrawl
 go 1.25.0
 
 require github.com/mattn/go-sqlite3 v1.14.34
+
+require golang.org/x/crypto v0.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=

--- a/handlers.go
+++ b/handlers.go
@@ -4,21 +4,43 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"html/template"
+	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 type Entry struct {
-	ID        string
-	Title     string
-	Body      string
-	CreatedAt time.Time
-	ExpiresAt *time.Time
+	ID           string
+	Title        string
+	Body         string
+	CreatedAt    time.Time
+	ExpiresAt    *time.Time
+	PasswordHash *string
+	Locked       bool // set by listEntries for sidebar icon
+}
+
+func (e *Entry) IsLocked() bool {
+	return e.PasswordHash != nil && *e.PasswordHash != ""
+}
+
+func hashPassword(password string) (string, error) {
+	h, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(h), err
+}
+
+func verifyPassword(entry *Entry, password string) bool {
+	if !entry.IsLocked() {
+		return true
+	}
+	return bcrypt.CompareHashAndPassword([]byte(*entry.PasswordHash), []byte(password)) == nil
 }
 
 var tmpl *template.Template
@@ -29,6 +51,13 @@ const maxTitleLen = 200
 
 func init() {
 	funcMap := template.FuncMap{
+		"dict": func(pairs ...any) map[string]any {
+			m := make(map[string]any, len(pairs)/2)
+			for i := 0; i < len(pairs)-1; i += 2 {
+				m[pairs[i].(string)] = pairs[i+1]
+			}
+			return m
+		},
 		"timeago": func(t time.Time) string {
 			d := time.Since(t)
 			switch {
@@ -139,14 +168,25 @@ func handleCreate(w http.ResponseWriter, r *http.Request) {
 		expiresStr = &s
 	}
 
-	_, err := db.Exec("INSERT INTO entries (id, title, body, expires_at) VALUES (?, ?, ?, ?)", id, title, body, expiresStr)
+	var pwHash *string
+	if pw := r.FormValue("password"); pw != "" {
+		h, err := hashPassword(pw)
+		if err != nil {
+			log.Println("error hashing password:", err)
+			http.Error(w, "Internal Server Error", 500)
+			return
+		}
+		pwHash = &h
+	}
+
+	_, err := db.Exec("INSERT INTO entries (id, title, body, expires_at, password_hash) VALUES (?, ?, ?, ?, ?)", id, title, body, expiresStr, pwHash)
 	if err != nil {
 		log.Println("error creating entry:", err)
 		http.Error(w, "Internal Server Error", 500)
 		return
 	}
 
-	entry := Entry{ID: id, Title: title, Body: body, CreatedAt: time.Now(), ExpiresAt: expiresAt}
+	entry := Entry{ID: id, Title: title, Body: body, CreatedAt: time.Now(), ExpiresAt: expiresAt, PasswordHash: pwHash}
 	entries, _ := listEntries(0)
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -198,8 +238,25 @@ func handleView(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if entry.IsLocked() {
+		data := map[string]any{"Entry": entry}
+		if r.Header.Get("HX-Request") == "true" {
+			tmpl.ExecuteTemplate(w, "unlock-form", data)
+			return
+		}
+		entries, _ := listEntries(0)
+		data["Entries"] = entries
+		tmpl.ExecuteTemplate(w, "index.html", map[string]any{
+			"Entries":     entries,
+			"LockedEntry": entry,
+		})
+		return
+	}
+
 	if r.Header.Get("HX-Request") == "true" {
-		tmpl.ExecuteTemplate(w, "view-content", entry)
+		tmpl.ExecuteTemplate(w, "view-content", map[string]any{
+			"Entry": entry,
+		})
 		return
 	}
 
@@ -207,6 +264,34 @@ func handleView(w http.ResponseWriter, r *http.Request) {
 	tmpl.ExecuteTemplate(w, "index.html", map[string]any{
 		"Entries":   entries,
 		"ViewEntry": entry,
+	})
+}
+
+func handleUnlock(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !validID.MatchString(id) {
+		http.NotFound(w, r)
+		return
+	}
+
+	entry, err := getEntry(id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	password := r.FormValue("password")
+	if !verifyPassword(entry, password) {
+		tmpl.ExecuteTemplate(w, "unlock-form", map[string]any{
+			"Entry": entry,
+			"Error": "Incorrect password",
+		})
+		return
+	}
+
+	tmpl.ExecuteTemplate(w, "view-content", map[string]any{
+		"Entry":    entry,
+		"Password": password,
 	})
 }
 
@@ -218,6 +303,17 @@ func handleEdit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
+	entry, err := getEntry(id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	if entry.IsLocked() && !verifyPassword(entry, r.FormValue("password")) {
+		http.Error(w, "incorrect password", 403)
+		return
+	}
 
 	title := sanitize(strings.TrimSpace(r.FormValue("title")))
 	body := sanitize(r.FormValue("body"))
@@ -251,13 +347,14 @@ func handleEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entry, _ := getEntry(id)
+	entry, _ = getEntry(id)
 
 	if r.Header.Get("HX-Request") == "true" {
 		entries, _ := listEntries(0)
 		tmpl.ExecuteTemplate(w, "edited-response", map[string]any{
-			"Entry":   entry,
-			"Entries": entries,
+			"Entry":    entry,
+			"Entries":  entries,
+			"Password": r.FormValue("password"),
 		})
 		return
 	}
@@ -278,13 +375,41 @@ func handleEditForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tmpl.ExecuteTemplate(w, "edit-form", entry)
+	password := r.URL.Query().Get("password")
+	if entry.IsLocked() && !verifyPassword(entry, password) {
+		http.Error(w, "incorrect password", 403)
+		return
+	}
+
+	tmpl.ExecuteTemplate(w, "edit-form", map[string]any{
+		"Entry":    entry,
+		"Password": password,
+	})
 }
 
 func handleDelete(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if !validID.MatchString(id) {
 		http.NotFound(w, r)
+		return
+	}
+
+	entry, err := getEntry(id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	password := r.URL.Query().Get("password")
+	if password == "" && r.Body != nil {
+		b, _ := io.ReadAll(io.LimitReader(r.Body, 4096))
+		if vals, e := url.ParseQuery(string(b)); e == nil {
+			password = vals.Get("password")
+		}
+	}
+
+	if entry.IsLocked() && !verifyPassword(entry, password) {
+		http.Error(w, "incorrect password", 403)
 		return
 	}
 
@@ -325,6 +450,11 @@ func handleDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if entry.IsLocked() && !verifyPassword(entry, r.URL.Query().Get("password")) {
+		http.Error(w, "incorrect password", 403)
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+entry.Title+".txt\"")
 	w.Write([]byte(entry.Body))
@@ -336,7 +466,7 @@ func listEntries(page int) ([]Entry, error) {
 	offset := page * limit
 
 	rows, err := db.Query(
-		"SELECT id, title, created_at FROM entries WHERE expires_at IS NULL OR expires_at > datetime('now') ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?",
+		"SELECT id, title, created_at, password_hash IS NOT NULL FROM entries WHERE expires_at IS NULL OR expires_at > datetime('now') ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?",
 		limit, offset,
 	)
 	if err != nil {
@@ -348,7 +478,7 @@ func listEntries(page int) ([]Entry, error) {
 	for rows.Next() {
 		var e Entry
 		var createdAt string
-		if err := rows.Scan(&e.ID, &e.Title, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.Title, &createdAt, &e.Locked); err != nil {
 			continue
 		}
 		e.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
@@ -363,8 +493,8 @@ func getEntry(id string) (*Entry, error) {
 	var createdAt string
 	var expiresAt *string
 	err := db.QueryRow(
-		"SELECT id, title, body, created_at, expires_at FROM entries WHERE id = ? AND (expires_at IS NULL OR expires_at > datetime('now'))", id,
-	).Scan(&entry.ID, &entry.Title, &entry.Body, &createdAt, &expiresAt)
+		"SELECT id, title, body, created_at, expires_at, password_hash FROM entries WHERE id = ? AND (expires_at IS NULL OR expires_at > datetime('now'))", id,
+	).Scan(&entry.ID, &entry.Title, &entry.Body, &createdAt, &expiresAt, &entry.PasswordHash)
 	if err != nil {
 		return nil, err
 	}
@@ -373,6 +503,7 @@ func getEntry(id string) (*Entry, error) {
 		t, _ := time.Parse(time.RFC3339, *expiresAt)
 		entry.ExpiresAt = &t
 	}
+	entry.Locked = entry.IsLocked()
 	return &entry, nil
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -42,6 +42,7 @@ func newMux() *http.ServeMux {
 	mux.HandleFunc("POST /api/entries", handleCreate)
 	mux.HandleFunc("GET /api/entries", handleList)
 	mux.HandleFunc("GET /e/{id}", handleView)
+	mux.HandleFunc("POST /e/{id}/unlock", handleUnlock)
 	mux.HandleFunc("PUT /api/entries/{id}", handleEdit)
 	mux.HandleFunc("GET /api/entries/{id}/edit", handleEditForm)
 	mux.HandleFunc("DELETE /api/entries/{id}", handleDelete)
@@ -1044,5 +1045,386 @@ func assertNotContains(t *testing.T, body, substr, label string) {
 	t.Helper()
 	if strings.Contains(body, substr) {
 		t.Errorf("expected %s to NOT contain %q", label, substr)
+	}
+}
+
+func createLockedTestEntry(t *testing.T, baseURL, title, body, password string) string {
+	t.Helper()
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	form := url.Values{"title": {title}, "body": {body}, "password": {password}}
+	resp, err := client.PostForm(baseURL+"/api/entries", form)
+	if err != nil {
+		t.Fatal("create locked entry failed:", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 303 {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
+	}
+
+	return strings.TrimPrefix(resp.Header.Get("Location"), "/e/")
+}
+
+func TestCreateEntryWithPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Secret Entry", "secret body", "mypass123")
+
+	entry, err := getEntry(id)
+	if err != nil {
+		t.Fatal("failed to get entry:", err)
+	}
+
+	if !entry.IsLocked() {
+		t.Fatal("expected entry to be locked")
+	}
+}
+
+func TestLockedEntryShowsUnlockForm(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Locked View", "hidden content", "pass123")
+
+	resp, err := http.Get(srv.URL + "/e/" + id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	assertContains(t, body, "unlock-form", "unlock form")
+	assertContains(t, body, "password-protected", "protection message")
+	assertContains(t, body, "Locked View", "title should be visible")
+	assertNotContains(t, body, "hidden content", "body should NOT be visible")
+}
+
+func TestLockedEntryHTMX_ShowsUnlockForm(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "HTMX Locked", "secret stuff", "pass456")
+
+	req, _ := http.NewRequest("GET", srv.URL+"/e/"+id, nil)
+	req.Header.Set("HX-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	assertContains(t, body, "unlock-form", "unlock form in HTMX response")
+	assertNotContains(t, body, "secret stuff", "body should NOT be visible")
+}
+
+func TestUnlockWithCorrectPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Unlock Test", "revealed content", "correctpw")
+
+	form := url.Values{"password": {"correctpw"}}
+	req, _ := http.NewRequest("POST", srv.URL+"/e/"+id+"/unlock", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	assertContains(t, body, "revealed content", "body should be visible after unlock")
+	assertContains(t, body, "Unlock Test", "title should be visible")
+	assertContains(t, body, "view-content", "should render view-content template")
+}
+
+func TestUnlockWithWrongPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Wrong PW", "still hidden", "rightpw")
+
+	form := url.Values{"password": {"wrongpw"}}
+	req, _ := http.NewRequest("POST", srv.URL+"/e/"+id+"/unlock", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Incorrect password", "error message")
+	assertContains(t, body, "unlock-form", "should show unlock form again")
+	assertNotContains(t, body, "still hidden", "body should NOT be visible")
+}
+
+func TestEditLockedEntry(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Edit Locked", "original locked", "editpw")
+
+	form := url.Values{"title": {"Edited Locked"}, "body": {"edited locked body"}, "password": {"editpw"}}
+	req, _ := http.NewRequest("PUT", srv.URL+"/api/entries/"+id, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Edited Locked", "updated title")
+}
+
+func TestEditLockedEntryWrongPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "No Edit", "protected", "rightpw")
+
+	form := url.Values{"title": {"Hacked"}, "body": {"hacked body"}, "password": {"wrongpw"}}
+	req, _ := http.NewRequest("PUT", srv.URL+"/api/entries/"+id, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteLockedEntry(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Delete Locked", "will be deleted", "delpw")
+
+	form := url.Values{"password": {"delpw"}}
+	req, _ := http.NewRequest("DELETE", srv.URL+"/api/entries/"+id, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Entry deleted", "deleted confirmation")
+}
+
+func TestDeleteLockedEntryWrongPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "No Delete", "protected", "rightpw")
+
+	form := url.Values{"password": {"wrongpw"}}
+	req, _ := http.NewRequest("DELETE", srv.URL+"/api/entries/"+id, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestDownloadLockedEntry(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Download Locked", "locked download", "dlpw")
+
+	resp, err := http.Get(srv.URL + "/e/" + id + "/download?password=dlpw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 with correct password, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	if body != "locked download" {
+		t.Fatalf("expected body content, got %q", body)
+	}
+}
+
+func TestDownloadLockedEntryWrongPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "DL No Access", "secret", "rightpw")
+
+	resp, err := http.Get(srv.URL + "/e/" + id + "/download?password=wrongpw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestLockedEntryInSidebar(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	createLockedTestEntry(t, srv.URL, "Sidebar Locked", "body", "pw123")
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Sidebar Locked", "locked entry title in sidebar")
+	assertContains(t, body, "lock-icon", "lock icon in sidebar")
+}
+
+func TestUnlockedEntryNoPasswordRequired(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createTestEntry(t, srv.URL, "Open Entry", "freely accessible")
+
+	resp, err := http.Get(srv.URL + "/e/" + id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	assertContains(t, body, "freely accessible", "body should be visible without password")
+	assertNotContains(t, body, "unlock-form", "should NOT show unlock form")
+}
+
+func TestEditFormLockedEntry(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "Edit Form Locked", "locked body", "formpw")
+
+	resp, err := http.Get(srv.URL + "/api/entries/" + id + "/edit?password=formpw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 with correct password, got %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	assertContains(t, body, "Edit Form Locked", "pre-filled title")
+	assertContains(t, body, "locked body", "pre-filled body")
+}
+
+func TestEditFormLockedEntryWrongPassword(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(newMux())
+	defer srv.Close()
+
+	id := createLockedTestEntry(t, srv.URL, "No Edit Form", "protected", "rightpw")
+
+	resp, err := http.Get(srv.URL + "/api/entries/" + id + "/edit?password=wrongpw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 	mux.HandleFunc("PUT /api/entries/{id}", handleEdit)
 	mux.HandleFunc("GET /api/entries/{id}/edit", handleEditForm)
 	mux.HandleFunc("DELETE /api/entries/{id}", handleDelete)
+	mux.HandleFunc("POST /e/{id}/unlock", handleUnlock)
 	mux.HandleFunc("GET /e/{id}/download", handleDownload)
 	mux.Handle("GET /static/", cacheStatic(http.FileServerFS(staticFS)))
 
@@ -71,19 +72,20 @@ func main() {
 func initDB() error {
 	_, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS entries (
-			id         TEXT PRIMARY KEY,
-			title      TEXT NOT NULL,
-			body       TEXT NOT NULL,
-			created_at DATETIME DEFAULT (datetime('now')),
-			expires_at DATETIME
+			id            TEXT PRIMARY KEY,
+			title         TEXT NOT NULL,
+			body          TEXT NOT NULL,
+			created_at    DATETIME DEFAULT (datetime('now')),
+			expires_at    DATETIME,
+			password_hash TEXT
 		);
 		CREATE INDEX IF NOT EXISTS idx_entries_created ON entries(created_at DESC);
 	`)
 	if err != nil {
 		return err
 	}
-	// migrate: add expires_at if upgrading from older schema
 	db.Exec("ALTER TABLE entries ADD COLUMN expires_at DATETIME")
+	db.Exec("ALTER TABLE entries ADD COLUMN password_hash TEXT")
 	return nil
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -446,6 +446,74 @@ html, body {
     transition: opacity 0.3s;
 }
 
+/* Password input */
+.input-password {
+    padding: 5px 10px;
+    font-size: 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text);
+    font-family: var(--font-sans);
+    outline: none;
+    width: 140px;
+    transition: border-color 0.15s;
+}
+
+.input-password:focus {
+    border-color: var(--accent);
+}
+
+.input-password::placeholder {
+    color: var(--text-muted);
+}
+
+/* Lock icon */
+.lock-icon {
+    font-size: 11px;
+    opacity: 0.7;
+}
+
+/* Unlock form */
+.unlock-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    text-align: center;
+}
+
+.unlock-title {
+    font-size: 22px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.unlock-text {
+    color: var(--text-muted);
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+.unlock-error {
+    color: #f85149;
+    font-size: 13px;
+    margin-bottom: 16px;
+}
+
+.unlock-form {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.unlock-input {
+    width: 220px;
+    padding: 8px 14px;
+    font-size: 14px;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
     width: 6px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,8 +24,10 @@
         </aside>
         <main class="main">
             <div id="content-area" class="editor">
-                {{if .ViewEntry}}
-                    {{template "view-content" .ViewEntry}}
+                {{if .LockedEntry}}
+                    {{template "unlock-form" dict "Entry" .LockedEntry}}
+                {{else if .ViewEntry}}
+                    {{template "view-content" dict "Entry" .ViewEntry}}
                 {{else}}
                 <form hx-post="/api/entries" hx-target="#content-area" hx-swap="innerHTML">
                     {{template "form-fields" .}}
@@ -46,6 +48,7 @@
     </div>
 
     <script>
+    var _currentPassword = '';
     function copyLink(id) {
         const url = window.location.origin + '/e/' + id;
         navigator.clipboard.writeText(url).then(() => {
@@ -64,6 +67,7 @@
     function showEditor() {
         history.pushState(null, '', '/');
         clearActive();
+        _currentPassword = '';
         document.getElementById('content-area').innerHTML = `
             <form hx-post="/api/entries" hx-target="#content-area" hx-swap="innerHTML">
                 <input type="text" name="title" placeholder="Heading" class="input-title" required autofocus>
@@ -71,6 +75,7 @@
                 <div class="editor-footer">
                     <span class="char-count">0 chars · 0 words</span>
                     <div class="form-actions">
+                        <input type="password" name="password" placeholder="Password (optional)" class="input-password">
                         <select name="ttl" class="ttl-select">
                             <option value="">No expiry</option>
                             <option value="1h">1 hour</option>
@@ -86,12 +91,15 @@
         htmx.process(document.getElementById('content-area'));
         document.querySelector('.input-title').focus();
     }
-    function confirmDelete(id) {
+    function confirmDelete(id, pw) {
         const modal = document.getElementById('delete-modal');
         modal.classList.add('visible');
         document.getElementById('confirm-delete-btn').onclick = function() {
             closeModal();
-            htmx.ajax('DELETE', '/api/entries/' + id, { target: '#content-area', swap: 'innerHTML' });
+            htmx.ajax('DELETE', '/api/entries/' + id, {
+                target: '#content-area', swap: 'innerHTML',
+                values: pw ? { password: pw } : {}
+            });
         };
     }
     function closeModal() {
@@ -131,8 +139,10 @@
         const counter = el.closest('form').querySelector('.char-count');
         if (counter) counter.textContent = chars + ' chars · ' + words + ' words';
     }
-    function downloadEntry(id) {
-        window.location.href = '/e/' + id + '/download';
+    function downloadEntry(id, pw) {
+        let url = '/e/' + id + '/download';
+        if (pw) url += '?password=' + encodeURIComponent(pw);
+        window.location.href = url;
     }
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape') closeModal();
@@ -157,6 +167,7 @@
 <div class="editor-footer">
     <span class="char-count">0 chars · 0 words</span>
     <div class="form-actions">
+        <input type="password" name="password" placeholder="Password (optional)" class="input-password">
         <select name="ttl" class="ttl-select">
             <option value="">No expiry</option>
             <option value="1h">1 hour</option>
@@ -172,7 +183,7 @@
 {{define "entry-items"}}
 {{range .Entries}}
 <a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()">
-    <span class="entry-title">{{.Title}}</span>
+    <span class="entry-title">{{if .Locked}}<span class="lock-icon">&#128274;</span> {{end}}{{.Title}}</span>
     <span class="entry-time">{{timeago .CreatedAt}}</span>
 </a>
 {{else}}
@@ -183,7 +194,7 @@
 {{define "entry-list"}}
 {{range .Entries}}
 <a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()">
-    <span class="entry-title">{{.Title}}</span>
+    <span class="entry-title">{{if .Locked}}<span class="lock-icon">&#128274;</span> {{end}}{{.Title}}</span>
     <span class="entry-time">{{timeago .CreatedAt}}</span>
 </a>
 {{end}}
@@ -197,26 +208,43 @@
 {{end}}
 {{end}}
 
+{{define "unlock-form"}}
+<div class="unlock-container">
+    <h2 class="unlock-title">&#128274; {{.Entry.Title}}</h2>
+    <p class="unlock-text">This entry is password-protected.</p>
+    {{if .Error}}<p class="unlock-error">{{.Error}}</p>{{end}}
+    <form hx-post="/e/{{.Entry.ID}}/unlock" hx-target="#content-area" hx-swap="innerHTML" class="unlock-form">
+        <input type="password" name="password" placeholder="Enter password" class="input-password unlock-input" required autofocus>
+        <button type="submit" class="btn btn-primary">Unlock</button>
+    </form>
+</div>
+<script>setActive('{{.Entry.ID}}');</script>
+{{end}}
+
 {{define "view-content"}}
 <article class="view-content">
     <div class="view-topbar">
-        <button class="btn btn-small" id="copytxt-btn-{{.ID}}" onclick="copyText('{{.ID}}')">Copy Text</button>
-        <button class="btn btn-small" id="copy-btn-{{.ID}}" onclick="copyLink('{{.ID}}')">Copy Link</button>
-        <button class="btn btn-small" onclick="downloadEntry('{{.ID}}')">Download</button>
-        <button class="btn btn-small" hx-get="/api/entries/{{.ID}}/edit" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
-        <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.ID}}')">Delete</button>
+        <button class="btn btn-small" id="copytxt-btn-{{.Entry.ID}}" onclick="copyText('{{.Entry.ID}}')">Copy Text</button>
+        <button class="btn btn-small" id="copy-btn-{{.Entry.ID}}" onclick="copyLink('{{.Entry.ID}}')">Copy Link</button>
+        <button class="btn btn-small" onclick="downloadEntry('{{.Entry.ID}}', _currentPassword)">Download</button>
+        <button class="btn btn-small" hx-get="/api/entries/{{.Entry.ID}}/edit{{if .Password}}?password={{.Password}}{{end}}" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
+        <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.Entry.ID}}', _currentPassword)">Delete</button>
     </div>
-    <h1 class="view-title">{{.Title}}</h1>
-    <time class="view-time">{{.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}{{if .ExpiresAt}} · expires {{.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}</time>
-    <pre class="view-body">{{.Body}}</pre>
+    <h1 class="view-title">{{.Entry.Title}}</h1>
+    <time class="view-time">{{.Entry.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}{{if .Entry.ExpiresAt}} · expires {{.Entry.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}{{if .Entry.Locked}} · &#128274; locked{{end}}</time>
+    <pre class="view-body">{{.Entry.Body}}</pre>
 </article>
-<script>setActive('{{.ID}}');</script>
+<script>
+setActive('{{.Entry.ID}}');
+_currentPassword = '{{.Password}}';
+</script>
 {{end}}
 
 {{define "edit-form"}}
-<form hx-put="/api/entries/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML">
-    <input type="text" name="title" value="{{.Title}}" class="input-title" required autofocus>
-    <textarea name="body" class="input-body" required oninput="updateCount(this)">{{.Body}}</textarea>
+<form hx-put="/api/entries/{{.Entry.ID}}" hx-target="#content-area" hx-swap="innerHTML">
+    {{if .Password}}<input type="hidden" name="password" value="{{.Password}}">{{end}}
+    <input type="text" name="title" value="{{.Entry.Title}}" class="input-title" required autofocus>
+    <textarea name="body" class="input-body" required oninput="updateCount(this)">{{.Entry.Body}}</textarea>
     <div class="editor-footer">
         <span class="char-count">0 chars · 0 words</span>
         <div class="form-actions">
@@ -227,7 +255,7 @@
                 <option value="7d">7 days</option>
                 <option value="30d">30 days</option>
             </select>
-            <button type="button" class="btn btn-small" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML">Cancel</button>
+            <button type="button" class="btn btn-small" hx-get="/e/{{.Entry.ID}}" hx-target="#content-area" hx-swap="innerHTML">Cancel</button>
             <button type="submit" class="btn btn-primary">Save Changes</button>
         </div>
     </div>
@@ -248,16 +276,17 @@
     <div class="view-topbar">
         <button class="btn btn-small" id="copytxt-btn-{{.Entry.ID}}" onclick="copyText('{{.Entry.ID}}')">Copy Text</button>
         <button class="btn btn-small" id="copy-btn-{{.Entry.ID}}" onclick="copyLink('{{.Entry.ID}}')">Copy Link</button>
-        <button class="btn btn-small" onclick="downloadEntry('{{.Entry.ID}}')">Download</button>
-        <button class="btn btn-small" hx-get="/api/entries/{{.Entry.ID}}/edit" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
-        <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.Entry.ID}}')">Delete</button>
+        <button class="btn btn-small" onclick="downloadEntry('{{.Entry.ID}}', _currentPassword)">Download</button>
+        <button class="btn btn-small" hx-get="/api/entries/{{.Entry.ID}}/edit{{if .Password}}?password={{.Password}}{{end}}" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
+        <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.Entry.ID}}', _currentPassword)">Delete</button>
     </div>
     <h1 class="view-title">{{.Entry.Title}}</h1>
     <time class="view-time">{{.Entry.CreatedAt.Format "Jan 2, 2006 at 3:04 PM"}}{{if .Entry.ExpiresAt}} · expires {{.Entry.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}</time>
     <pre class="view-body">{{.Entry.Body}}</pre>
 </article>
 <script>
-document.getElementById('entries-list').innerHTML = `{{range .Entries}}<a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()"><span class="entry-title">{{.Title}}</span><span class="entry-time">{{timeago .CreatedAt}}</span></a>{{end}}`;
+_currentPassword = '{{.Password}}';
+document.getElementById('entries-list').innerHTML = `{{range .Entries}}<a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()"><span class="entry-title">{{if .Locked}}<span class="lock-icon">&#128274;</span> {{end}}{{.Title}}</span><span class="entry-time">{{timeago .CreatedAt}}</span></a>{{end}}`;
 htmx.process(document.getElementById('entries-list'));
 setActive('{{.Entry.ID}}');
 setTimeout(() => {
@@ -276,16 +305,16 @@ setTimeout(() => {
     <div class="view-topbar">
         <button class="btn btn-small" id="copytxt-btn-{{.ID}}" onclick="copyText('{{.ID}}')">Copy Text</button>
         <button class="btn btn-small" id="copy-btn-{{.ID}}" onclick="copyLink('{{.ID}}')">Copy Link</button>
-        <button class="btn btn-small" onclick="downloadEntry('{{.ID}}')">Download</button>
+        <button class="btn btn-small" onclick="downloadEntry('{{.ID}}', _currentPassword)">Download</button>
         <button class="btn btn-small" hx-get="/api/entries/{{.ID}}/edit" hx-target="#content-area" hx-swap="innerHTML">Edit</button>
-        <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.ID}}')">Delete</button>
+        <button class="btn btn-danger btn-small" onclick="confirmDelete('{{.ID}}', _currentPassword)">Delete</button>
     </div>
     <h1 class="view-title">{{.Entry.Title}}</h1>
     <time class="view-time">just now{{if .Entry.ExpiresAt}} · expires {{.Entry.ExpiresAt.Format "Jan 2, 2006 at 3:04 PM"}}{{end}}</time>
     <pre class="view-body">{{.Entry.Body}}</pre>
 </article>
 <script>
-document.getElementById('entries-list').innerHTML = `{{range .Entries}}<a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()"><span class="entry-title">{{.Title}}</span><span class="entry-time">{{timeago .CreatedAt}}</span></a>{{end}}`;
+document.getElementById('entries-list').innerHTML = `{{range .Entries}}<a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()"><span class="entry-title">{{if .Locked}}<span class="lock-icon">&#128274;</span> {{end}}{{.Title}}</span><span class="entry-time">{{timeago .CreatedAt}}</span></a>{{end}}`;
 htmx.process(document.getElementById('entries-list'));
 history.pushState(null, '', '/e/{{.ID}}');
 setActive('{{.ID}}');
@@ -300,6 +329,7 @@ setActive('{{.ID}}');
     <div class="editor-footer">
         <span class="char-count">0 chars · 0 words</span>
         <div class="form-actions">
+            <input type="password" name="password" placeholder="Password (optional)" class="input-password">
             <select name="ttl" class="ttl-select">
                 <option value="">No expiry</option>
                 <option value="1h">1 hour</option>
@@ -312,7 +342,8 @@ setActive('{{.ID}}');
     </div>
 </form>
 <script>
-document.getElementById('entries-list').innerHTML = `{{range .Entries}}<a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()"><span class="entry-title">{{.Title}}</span><span class="entry-time">{{timeago .CreatedAt}}</span></a>{{else}}<div class="empty-state">No entries yet</div>{{end}}`;
+_currentPassword = '';
+document.getElementById('entries-list').innerHTML = `{{range .Entries}}<a href="/e/{{.ID}}" class="entry-item" hx-get="/e/{{.ID}}" hx-target="#content-area" hx-swap="innerHTML" hx-push-url="true" onclick="event.preventDefault()"><span class="entry-title">{{if .Locked}}<span class="lock-icon">&#128274;</span> {{end}}{{.Title}}</span><span class="entry-time">{{timeago .CreatedAt}}</span></a>{{else}}<div class="empty-state">No entries yet</div>{{end}}`;
 htmx.process(document.getElementById('entries-list'));
 history.pushState(null, '', '/');
 clearActive();


### PR DESCRIPTION
## Summary

- Add optional password protection for entries using bcrypt hashing (`golang.org/x/crypto/bcrypt`)
- Locked entries show a password prompt instead of content; all actions (view, edit, delete, download) require the correct password
- Lock icon (🔒) displayed in sidebar for protected entries
- New `POST /e/{id}/unlock` route for password verification
- 14 new integration tests covering all password-related flows (49 total)

## Test plan

- [x] All 49 tests pass (`go test -v ./...`)
- [x] Create entry without password — works as before
- [x] Create entry with password — lock icon in sidebar, unlock form shown on view
- [x] Wrong password — error message displayed
- [x] Correct password — content revealed with edit/delete/download buttons
- [x] Edit/delete/download locked entries — requires password
- [x] Browser-verified UI styling and flow