### PR TITLE
chore: enable Renovate automerge for minor/patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Add `automerge: true` for minor and patch dependency updates in `renovate.json`, matching tablio, bolt, and xproxy.