### PR TITLE
chore: add platformAutomerge and 7-day minimum release age to Renovate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "platformAutomerge": true,
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Enable `platformAutomerge` for auto-merging Renovate PRs
- Add `minimumReleaseAge: 7 days` to reduce supply chain attack exposure
- Enable `automerge` for minor and patch updates